### PR TITLE
[RKT-245] Show launch dateTime in local timezone + tooltip

### DIFF
--- a/src/components/launch.tsx
+++ b/src/components/launch.tsx
@@ -1,6 +1,7 @@
+import React from "react";
 import { useParams, Link as RouterLink } from "react-router-dom";
 import { format as timeAgo } from "timeago.js";
-import { Watch, MapPin, Navigation, Layers } from "react-feather";
+import { Watch, MapPin, Navigation, Layers, Info } from "react-feather";
 import {
   Flex,
   Heading,
@@ -18,10 +19,12 @@ import {
   Stack,
   AspectRatio,
   StatGroup,
+  Tooltip,
+  Icon,
 } from "@chakra-ui/react";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, TimeZoneDisplayKind } from "../utils/format-date";
 import { Error } from "./error";
 import { Breadcrumbs } from "./breadcrumbs";
 
@@ -172,6 +175,8 @@ type TimeAndLocationProps = {
 };
 
 const TimeAndLocation = ({ launch }: TimeAndLocationProps) => {
+  const [tooltipIsOpen, setTooltipIsOpen] = React.useState(false);
+  const launchDateUserTime = formatDateTime({ kind: TimeZoneDisplayKind.user, timestamp: launch.launch_date_local });
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>
@@ -181,8 +186,16 @@ const TimeAndLocation = ({ launch }: TimeAndLocationProps) => {
             Launch Date
           </Box>
         </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+        <StatNumber display="inline" fontSize={["md", "xl"]}>
+          {formatDateTime({ kind: TimeZoneDisplayKind.local, timestamp: launch.launch_date_local, launchSite: launch.launch_site.site_id })}
+          <Tooltip hasArrow isOpen={tooltipIsOpen} label={launchDateUserTime} >
+            <Icon alt={launchDateUserTime}
+              onMouseEnter={() => setTooltipIsOpen(true)}
+              onMouseLeave={() => setTooltipIsOpen(false)}
+              onTouchEnd={() => setTooltipIsOpen(!tooltipIsOpen)} marginLeft="0.2em">
+              <Info />
+            </Icon>
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -7,7 +7,52 @@ export const formatDate = (timestamp: Date) => {
   }).format(new Date(timestamp));
 };
 
-export const formatDateTime = (timestamp: Date) => {
+enum LaunchSite {
+  // Cape Canaveral Air Force Station Space Launch Complex 40
+  Cape_Canaveral = "ccafs_slc_40",
+  // Kennedy Space Center Historic Launch Complex 39A
+  Kennedy_Space_Center = "ksc_lc_39a",
+  // Vandenberg Air Force Base Space Launch Complex 4E
+  Vandenberg_Air_Force_Base = "vafb_slc_4e",
+}
+
+export enum TimeZoneDisplayKind {
+  local,
+  user,
+}
+
+type TimeZone =
+  | { kind: TimeZoneDisplayKind.local; timestamp: Date; launchSite: string }
+  | { kind: TimeZoneDisplayKind.user; timestamp: Date };
+
+/**
+ * @param {string} kind - Display time in local or user dateTime
+ * @param {string} timestamp
+ * @param {string} launchSite - Used to determine local dateTime
+ */
+export const formatDateTime = (args: TimeZone) => {
+  let timezone;
+  switch (args.kind) {
+    case TimeZoneDisplayKind.local:
+      // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      timezone =
+        args.launchSite ===
+        (LaunchSite.Cape_Canaveral || LaunchSite.Kennedy_Space_Center)
+          ? "America/New_York"
+          : args.launchSite === LaunchSite.Vandenberg_Air_Force_Base
+          ? "America/Los_Angeles"
+          : // TODO communicate unknown launchSite
+            undefined;
+      break;
+    case TimeZoneDisplayKind.user:
+      // When timeZone is undefined, dateTime is offset to user time
+      timezone = undefined;
+      break;
+    default:
+      // Default to old behavior
+      timezone = undefined;
+      break;
+  }
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -15,6 +60,7 @@ export const formatDateTime = (timestamp: Date) => {
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
+    timeZone: timezone,
     timeZoneName: "short",
-  }).format(new Date(timestamp));
+  }).format(new Date(args.timestamp));
 };


### PR DESCRIPTION
## Context

Addresses [RKT-245](https://spacerockets.atlassian.net/browse/RKT-245)

## Changes

- Add tooltip icon which supports hover and touch
- Map launch sites to timezones understood by DateTimeFormat API
- Extend formatDateTime utility so it can be used to display dateTime in user or local dateTime
- Document utility

## Screenshot

![Screenshot 2021-11-16 at 11 44 32](https://user-images.githubusercontent.com/59572064/141971232-59f817cd-c5a4-4dd0-8481-726da566fd59.png)

## TODO

- [ ] Rebase on master to test ([this PR](https://github.com/reverbePrintemps/jandreo-space-rockets/pull/1) broke launch and launch-pad) — alternatively wrap launchPadId and launchId in curlies.
- [ ] Communicate unknown launchSite

## Notes

- Using `isOpen` state for accessibility (mouse hover and touch events should both work)

## GIF

![GIF](https://media2.giphy.com/media/QBd2kLB5qDmysEXre9/giphy-downsized.gif?cid=6104955e3c11858a01a04ac6d793d07d544034bf0a2d6649&rid=giphy-downsized.gif&ct=g)
