### PR TITLE
[RKT-246] Load more launches upon scroll towards bottom of page

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,20 +5,44 @@ import { Launches } from "./launches";
 import { Launch } from "./launch";
 import { LaunchPads } from "./launch-pads";
 import { LaunchPad } from "./launch-pad";
-
+import { useEffect, useRef, useState } from "react";
 
 export const App = () => {
+  const [loadMore, setLoadMore] = useState(false);
+  const [pageHeight, setPageHeight] = useState(0);
+
+  const ref = useRef<HTMLDivElement>(null);
+  
+  const handleScroll = () => {
+    const position = window.pageYOffset;
+    if (position >= pageHeight) {
+      setLoadMore(true);
+    } else {
+      setLoadMore(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    if (ref.current) {
+      setPageHeight(ref.current.clientHeight);
+    }
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+
   return (
-    <>
+    <div ref={ref}>
       <NavBar />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/launches" element={<Launches />} />
+        <Route path="/launches" element={<Launches loadMore={loadMore} />} />
         <Route path="/launches/:launchId" element={<Launch />} />
         <Route path="/launch-pads" element={<LaunchPads />} />
         <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
       </Routes>
-    </>
+    </div>
   );
 };
 

--- a/src/components/launches.tsx
+++ b/src/components/launches.tsx
@@ -8,8 +8,13 @@ import { Error } from "./error";
 import { Breadcrumbs } from "./breadcrumbs";
 import { LoadMoreButton } from "./load-more-button";
 import { Launch } from "./launch";
+import { useEffect } from "react";
 
 const PAGE_SIZE = 12;
+
+type LaunchesProps = {
+  loadMore: boolean;
+}
 
 export type PastLaunchesResponse = {
   data?: Launch[][];
@@ -19,7 +24,7 @@ export type PastLaunchesResponse = {
   size?: number;
 };
 
-export const Launches = () => {
+export const Launches = ({loadMore}: LaunchesProps) => {
   const { data: pastLaunches, error, isValidating, setSize, size }: PastLaunchesResponse = useSpaceXPaginated(
     "/launches/past",
     {
@@ -28,6 +33,12 @@ export const Launches = () => {
       sort: "launch_date_utc",
     }
   );
+
+  const handleLoadMore = () => setSize(size + 1)
+
+  useEffect(() => {
+    handleLoadMore()
+  }, [loadMore])
 
   return (
     <>
@@ -41,7 +52,7 @@ export const Launches = () => {
         ))}
       </SimpleGrid>
       <LoadMoreButton
-        loadMore={() => setSize(size + 1)}
+        loadMore={handleLoadMore}
         data={pastLaunches}
         pageSize={PAGE_SIZE}
         isLoadingMore={isValidating}


### PR DESCRIPTION
## Context

Addresses [RKT-246](https://spacerockets.atlassian.net/browse/RKT-246)

Load more launches on scroll, removing the need to click on the load more button to load more launch

## Changes

On scroll:
- Get vertical window scroll offset
- Get App height
- If scroll position is nearing bottom of page, load more launches

## Notes

- Didn't think there's an immediate need to implement this behavior for launch pads for now. Given there are currently 6 launch pages and the page limit is 12. SpaceX still has 7 more launch pads to build before this becomes relevant for us :)

## TODO

- [ ] ¯\\\_(ツ)\_/¯

## GIF

![GIF](https://media.giphy.com/media/vvWhQsVAFkyisScAsM/giphy-downsized-large.gif)